### PR TITLE
fix: fixes bug where command line parsing of `-t, --ts-config` always returns undefined

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -88,7 +88,7 @@ function parseArgs() {
   return {
     projectDir: projectDir ? stringSchema.parse(projectDir) : undefined,
     safePackages: stringArraySchema.parse(options.safe ?? []),
-    tsConfigDir: options.tsConfigDir ? stringSchema.parse(options.tsConfigDir) : undefined,
+    tsConfigDir: options.tsConfig ? stringSchema.parse(options.tsConfig) : undefined,
     reportType: reporterSchema.parse(options.reporter ?? defaultReportType),
   };
 }


### PR DESCRIPTION
@omothm 

Essentially `Commandeer` parses options in `tsConfig` field instead of `tsConfigDir` field. 

Whatever you pass to `-t, --ts-config` flag was always going to be ignored and to set `tsConfigDir` to undefined.

Fixes #2 



Quite an awesome project. 
I'll add it to my stack for open source projects immediately.

I've been working on something similar with much less functionality for my enterprise projects (D,A,I + Ce & Ca metrics calculation script that's tightly coupled with codebase) inspired by Building Evolutionary Architectures book.